### PR TITLE
Close cursor when exiting normally, to avoid cursor leak.

### DIFF
--- a/orahlp/orahlp.go
+++ b/orahlp/orahlp.go
@@ -67,6 +67,7 @@ BEGIN
                   CHR(10);
       v_idx := rec_tab.NEXT(v_idx);
     END LOOP;
+  DBMS_SQL.CLOSE_CURSOR(c);
   EXCEPTION WHEN OTHERS THEN NULL;
     DBMS_SQL.CLOSE_CURSOR(c);
 	RAISE;


### PR DESCRIPTION
When testing the csvdump stuff, I found that I quickly ran into this:

`error dumping: Describe "SELECT * FROM foo": Stmt.exe Env.ociErrorNL ORA-01000: maximum open cursors exceeded
`

Closing the cursor before exiting normally fixed the issue.